### PR TITLE
Fix syntax error introduced by commit 600e054

### DIFF
--- a/release-version.sh
+++ b/release-version.sh
@@ -24,7 +24,6 @@ verify_gpg_settings () {
 	test "$SKIP_GPG" -o -f .travis/signingkey.asc.enc ||
 		die 'GPG configuration not found. Please use travisify.sh to add it.
 See also: https://github.com/scijava/pom-scijava/wiki/GPG-Signing'
-	fi
 }
 
 verify_git_settings () {


### PR DESCRIPTION
@ctrueden this line was left over when removing part of the skip-gpg test in https://github.com/scijava/scijava-scripts/commit/600e054e99d9864164b55fea105ee6fb1689209f.