### PR TITLE
travis-build.sh: Use conda activate

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -154,7 +154,7 @@ then
 	condaEnv=travis-scijava
 	test -d "$condaDir/envs/$condaEnv" && condaAction=update || condaAction=create
 	$condaDir/bin/conda env "$condaAction" -n "$condaEnv" -f environment.yml &&
-	source "$condaDir/bin/activate" "$condaEnv"
+	$condaDir/bin/conda activate "$condaEnv"
 	checkSuccess $?
 
 	echo travis_fold:end:scijava-conda


### PR DESCRIPTION
Newer versions of conda support activating an environment with `conda activate $env`, so let's use that recommended syntax instead of `source activate $env`.

I couldn't test this, but it hopefully fixes the Travis build failure here:
https://travis-ci.org/imagej/tutorials/builds/388369917
