### PR TITLE
travis-build.sh: Do not overwrite $MAVEN_OPTS, but extend

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -25,7 +25,7 @@ then
 
 	# NB: Suppress "Downloading/Downloaded" messages.
 	# See: https://stackoverflow.com/a/35653426/1207769
-	export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+	export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn" 
 
 	# Populate the settings.xml configuration.
 	mkdir -p "$HOME/.m2"


### PR DESCRIPTION
This PR changes `travis-build.sh` such that $MAVEN_OPTS is not overwritten, but extended as `MAVEN_OPTS="$MAVENOPTS [stuff defined in travis-build.sh]".