### PR TITLE
Change to OpenJDK 8

### DIFF
--- a/travisify.sh
+++ b/travisify.sh
@@ -115,7 +115,7 @@ process() {
 	# Add/update the Travis configuration file.
 	cat >"$tmpFile" <<EOL
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master


### PR DESCRIPTION
The new default environment on Travis CI (xenial) doesn't support Oracle JDK 8. Let's change to OpenJDK 8 as long as we need to stick to Java 8 in general.