### PR TITLE
Fix travisify.sh for version 1.8.12 of travis command line tools

### DIFF
--- a/travisify.sh
+++ b/travisify.sh
@@ -201,7 +201,7 @@ EOL
 				'#'*) continue;;
 			esac
 			info "Encrypting ${p%%=*}"
-			$EXEC travis encrypt --$mode "$p" --add env.global --repo "$repoSlug"
+			yes | $EXEC travis encrypt --$mode "$p" --add env.global --repo "$repoSlug"
 			test $? -eq 0 || die "Failed to encrypt variable '$p'"
 		done <"$varsFile"
 		$EXEC git commit "$travisConfig" -m "Travis: add encrypted environment variables"


### PR DESCRIPTION
Version 1.8.12 of travis command line tools asks for confirmation when encrypt and encrypt-file commands receive -a, --add flag.
This broke the `travisify.sh` script, because the default answer is "no".
