### PR TITLE
travisify.sh: respect default branch name

### DIFF
--- a/travisify.sh
+++ b/travisify.sh
@@ -82,8 +82,9 @@ process() {
 	esac
 	git fetch >/dev/null
 	git diff-index --quiet HEAD -- || die "Dirty working copy"
-	branch=$(git rev-parse --abbrev-ref HEAD)
-	test "$branch" = "master" || die "Non-master branch: $branch"
+	currentBranch=$(git rev-parse --abbrev-ref HEAD)
+	defaultBranch=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+	test "$currentBranch" = "$defaultBranch" || die "Non-default branch: $currentBranch"
 	git merge --ff --ff-only 'HEAD@{u}' >/dev/null ||
 		die "Cannot fast forward (local diverging?)"
 #	test "$(git rev-parse HEAD)" = "$(git rev-parse 'HEAD@{u}')" ||
@@ -124,7 +125,7 @@ language: java
 jdk: openjdk8
 branches:
   only:
-  - master
+  - $defaultBranch
   - "/.*-[0-9]+\\\\..*/"
 install: true
 script: "$travisBuildScript"

--- a/travisify.sh
+++ b/travisify.sh
@@ -83,7 +83,9 @@ process() {
 	git fetch >/dev/null
 	git diff-index --quiet HEAD -- || die "Dirty working copy"
 	currentBranch=$(git rev-parse --abbrev-ref HEAD)
-	defaultBranch=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+	upstreamBranch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+	remote=${upstreamBranch%/*}
+	defaultBranch=$(git remote show "$remote" | grep "HEAD branch" | sed 's/.*: //')
 	test "$currentBranch" = "$defaultBranch" || die "Non-default branch: $currentBranch"
 	git merge --ff --ff-only 'HEAD@{u}' >/dev/null ||
 		die "Cannot fast forward (local diverging?)"


### PR DESCRIPTION
See #36.

NB: Currently, the remote name `origin` is hard-coded. We should allow configuration similar to how it is done in `release-version.sh`.
