### PR TITLE
Force locale setting for the script

### DIFF
--- a/release-version.sh
+++ b/release-version.sh
@@ -8,6 +8,10 @@
 # Authors: Johannes Schindelin & Curtis Rueden
 # ============================================================================
 
+# -- Avoid localized output that might confuse the script --
+
+export LC_ALL=C
+
 # -- Functions --
 
 die () {


### PR DESCRIPTION
This avoids localized output that can confuse the script, e.g. when determining
the $defaultBranch.

We (as in @lguerard and me) were facing issues when trying to create a new
release using a `fr_FR` locale setting on Linux (Mint 20.1 / Ubuntu 20.04) as the
command for getting the default branch is failing there (the `grep` pattern doesn't
match on the french locale):

https://github.com/scijava/scijava-scripts/blob/8bd74a0ba6a33c6ece6d6f1937edadc0f2f71447/release-version.sh#L186

**PLEASE NOTE:** this is entirely untested on MacOS and Windows, although
in my experience using the `C` locale should be supported there as well.