### PR TITLE
fix: parsing for parentGAV and skipUpdateProjectLicense

### DIFF
--- a/release-version.sh
+++ b/release-version.sh
@@ -133,7 +133,12 @@ currentVersion=${projectDetails%%:*}
 projectDetails=${projectDetails#*:}
 licenseName=${projectDetails%%:*}
 projectDetails=${projectDetails#*:}
-parentGAV=${projectDetails%%:*}
+parentGroup=${projectDetails%%:*}
+projectDetails=${projectDetails#*:}
+parentArtifact=${projectDetails%%:*}
+projectDetails=${projectDetails#*:}
+parentVersion=${projectDetails%%:*}
+parentGAV="${parentGroup}:${parentArtifact}:${parentVersion}"
 skipUpdateProjectLicense=${projectDetails#*:}
 
 # -- Sanity checks --


### PR DESCRIPTION
fixes an issue with parsing `parentGAV` and `skipUpdateProjectLicense`. 

`parentGAV` was previously depending on being the last parsed parameter, since it has multiple `:` in the string. 
To correctly add more parameters after, we need to parse each parent part (group:artifact:version) before parsing the next argument.